### PR TITLE
Fix some compile errors on openSUSE Leap 15.0

### DIFF
--- a/src/dialog/wxmedit_about_dialog.h
+++ b/src/dialog/wxmedit_about_dialog.h
@@ -8,6 +8,10 @@
 #ifndef WXMEDIT_ABOUT_DIALOG_H
 #define WXMEDIT_ABOUT_DIALOG_H
 
+#ifndef wxTE_AUTO_SCROLL
+#define wxTE_AUTO_SCROLL 0
+#endif
+
 #ifdef _MSC_VER
 # pragma warning( push )
 # pragma warning( disable : 4996 )

--- a/src/dialog/wxmedit_options_dialog.cpp
+++ b/src/dialog/wxmedit_options_dialog.cpp
@@ -823,7 +823,7 @@ WXMEditOptionsDialog::WXMEditOptionsDialog(wxWindow* parent,wxWindowID id)
 	{
 		if(cd->menu_level==0)
 		{
-			tid=TreeCtrl1->AppendItem(menuRoot, FilterChar(wxGetTranslation(cd->text)));
+			tid=TreeCtrl1->AppendItem(menuRoot, FilterChar(wxGetTranslation(cd->text).wc_str()));
 			tree_stack.clear();
 			tree_stack.push_back(tid);
 			++cd;
@@ -840,7 +840,7 @@ WXMEditOptionsDialog::WXMEditOptionsDialog(wxWindow* parent,wxWindowID id)
 
 		if(cd->menu_ptr != 0)
 		{
-			tid=TreeCtrl1->AppendItem(tree_stack.back(), FilterChar(wxGetTranslation(cd->text)));
+			tid=TreeCtrl1->AppendItem(tree_stack.back(), FilterChar(wxGetTranslation(cd->text).wc_str()));
 			tree_stack.push_back(tid);
 		}
 		else if(cd->kind != wxITEM_SEPARATOR)
@@ -849,7 +849,7 @@ WXMEditOptionsDialog::WXMEditOptionsDialog(wxWindow* parent,wxWindowID id)
 			data->cmddata=cd;
 			TreeItemDataList.push_back(data);
 
-			tid=TreeCtrl1->AppendItem(tree_stack.back(), FilterChar(wxGetTranslation(cd->text)), cd->image_idx, cd->image_idx, data);
+			tid=TreeCtrl1->AppendItem(tree_stack.back(), FilterChar(wxGetTranslation(cd->text).wc_str()), cd->image_idx, cd->image_idx, data);
 			TreeCtrl1->SetItemBold(tid, true);
 		}
 

--- a/src/wxm/utils.cpp
+++ b/src/wxm/utils.cpp
@@ -205,7 +205,12 @@ bool FilePathEqual(const wxString& name1, const wxString& name2)
 
 unsigned long FilePathHash(const wxString& name)
 {
-	return wxStringHash::stringHash(FilePathNormalCase(name).wc_str());
+	const wchar_t* s = FilePathNormalCase(name).wc_str();
+#if wxMAJOR_VERSION == 2
+	return wxStringHash::stringHash(s);
+#else
+	return wxStringHash::wxCharStringHash(s);
+#endif
 }
 
 wxString& WxStrAppendUCS4(wxString& ws, ucs4_t ch)

--- a/src/wxm/utils.cpp
+++ b/src/wxm/utils.cpp
@@ -205,7 +205,7 @@ bool FilePathEqual(const wxString& name1, const wxString& name2)
 
 unsigned long FilePathHash(const wxString& name)
 {
-	return wxStringHash::wxCharStringHash(FilePathNormalCase(name));
+	return wxStringHash::stringHash(FilePathNormalCase(name).wc_str());
 }
 
 wxString& WxStrAppendUCS4(wxString& ws, ucs4_t ch)
@@ -564,7 +564,7 @@ std::wstring GetASCIIArtFontName()
 
 const wchar_t * LocalizeText(const wchar_t* txt)
 {
-	return wxGetTranslation(txt);
+	return wxGetTranslation(txt).wc_str();
 }
 
 namespace xm

--- a/src/wxmedit_app.cpp
+++ b/src/wxmedit_app.cpp
@@ -140,7 +140,7 @@ void send_message(Window madedit_win, const wxString &msg)
     Window mwin = XCreateSimpleWindow(g_Display, DefaultRootWindow(g_Display),
                     0,0,90,90,1,0,0);
 
-    const wxCharBuffer data_utf8 = wxConvUTF8.cWX2MB( msg );
+    const wxCharBuffer data_utf8 = wxConvUTF8.cWX2MB( msg.wc_str() );
     size_t datalen_utf8 = strlen(data_utf8);
 
     XChangeProperty(g_Display, mwin , g_MadEdit_atom, XA_STRING, 8,


### PR DESCRIPTION
When compile on openSUSE Leap 15.0(which have the following version of gcc & wxWidgets)
- `g++ -v` returns `gcc version 7.3.1 `
- `wx-config --version` returns `3.1.1`

There would be some errors,such as

- `src/dialog/wxmedit_about_dialog.cpp:75:103: error: ‘wxTE_AUTO_SCROLL’ was not declared in this scope`

- `src/dialog/wxmedit_options_dialog.cpp:826:77: error: cannot convert ‘const wxString’ to ‘const wxChar* {aka const wchar_t*}’ for argument ‘1’ to ‘wxString FilterChar(const wxChar*)’`

- `src/wxm/utils.cpp:208:23: error: ‘wxCharStringHash’ is not a member of ‘wxStringHash’`

- ...

This pull request fixes these errors, and please consider whether it is good to merge it. 

Thank you