### PR TITLE
fix some deprecated warnings

### DIFF
--- a/src/wxm/def.h
+++ b/src/wxm/def.h
@@ -33,6 +33,7 @@ typedef std::basic_string<ucs4_t> ucs4string;
 #if wxMAJOR_VERSION==2
   typedef int wxPrintOrientation;
 # define wxGetSelectedChoices wxGetMultipleChoices
+# define wxPENSTYLE_SOLID wxSOLID
 #endif
 
 typedef std::vector<size_t> LineNumberList;

--- a/src/wxm/edit/inframe.cpp
+++ b/src/wxm/edit/inframe.cpp
@@ -549,7 +549,7 @@ void InFrameWXMEdit::PrintTextPage(wxDC *dc, int pageNum)
 		return;
 
 	// draw a line between LineNumberArea and Text
-	dc->SetPen(*wxThePenList->FindOrCreatePen(*wxBLACK, 1, wxSOLID));
+	dc->SetPen(*wxThePenList->FindOrCreatePen(*wxBLACK, 1, wxPENSTYLE_SOLID));
 	int x1 = m_PrintRect.x + CachedLineNumberAreaWidth();
 	dc->DrawLine(x1, m_PrintRect.y, x1, m_PrintRect.y + (rowcount*m_RowHeight));
 }
@@ -784,7 +784,7 @@ void InFrameWXMEdit::PaintLineNumberArea(const wxColor & bgcolor, wxDC * dc, con
 	// paint background
 	if (GetSyntax()->nw_BgColor != bgcolor)
 	{
-		dc->SetPen(*wxThePenList->FindOrCreatePen(GetSyntax()->nw_BgColor, 1, wxSOLID));
+		dc->SetPen(*wxThePenList->FindOrCreatePen(GetSyntax()->nw_BgColor, 1, wxPENSTYLE_SOLID));
 		dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(GetSyntax()->nw_BgColor));
 		dc->DrawRectangle(rect);
 	}
@@ -797,7 +797,7 @@ void InFrameWXMEdit::PaintLineNumberArea(const wxColor & bgcolor, wxDC * dc, con
 		int b = m_RowHeight < 24 ? 1 : m_RowHeight / 24;
 
 		MadAttributes* attr = GetSyntax()->GetAttributes(aeBookmark);
-		dc->SetPen(*wxThePenList->FindOrCreatePen(attr->color, b, wxSOLID));
+		dc->SetPen(*wxThePenList->FindOrCreatePen(attr->color, b, wxPENSTYLE_SOLID));
 		dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(attr->bgcolor));
 
 		wxRect rdrect(rect.x + b/2, rect.y + b, rect.width - b, rect.height - b*3/2);

--- a/src/wxm/status_bar.cpp
+++ b/src/wxm/status_bar.cpp
@@ -23,7 +23,7 @@ void WXMStatusBar::Init(MadEditFrame* frame, wxWindowID id)
 	m_statusbar = new wxStatusBar(m_frame, id);
 
 #if defined(__WXGTK__)
-	m_statusbar->SetFont(wxFont(9, wxDEFAULT, wxNORMAL, wxNORMAL, false));
+	m_statusbar->SetFont(wxFont(9, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false));
 #endif
 }
 

--- a/src/wxm/utils.cpp
+++ b/src/wxm/utils.cpp
@@ -179,7 +179,7 @@ void SetDefaultMonoFont(wxWindow* win)
 {
 	const wxString fontname = xm::EncodingManager::Instance().GetSystemEncoding()->GetFontName().c_str();
 	int fontsize = win->GetFont().GetPointSize();
-	win->SetFont(wxFont(fontsize, wxDEFAULT, wxNORMAL, wxNORMAL, false, fontname));
+	win->SetFont(wxFont(fontsize, wxFONTFAMILY_DEFAULT, wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, fontname));
 }
 
 wxString FilePathNormalCase(const wxString& name)
@@ -206,7 +206,7 @@ bool FilePathEqual(const wxString& name1, const wxString& name2)
 unsigned long FilePathHash(const wxString& name)
 {
 	const wchar_t* s = FilePathNormalCase(name).wc_str();
-#if wxMAJOR_VERSION == 2
+#if wxMAJOR_VERSION == 3
 	return wxStringHash::stringHash(s);
 #else
 	return wxStringHash::wxCharStringHash(s);

--- a/src/wxmedit/wxm_syntax.cpp
+++ b/src/wxmedit/wxm_syntax.cpp
@@ -1211,7 +1211,7 @@ void MadSyntax::SetAttributes(MadAttributes *attr)
         attr != &m_SystemAttributes[aeActiveLine] &&
         attr != &m_SystemAttributes[aeBookmark] )
     {
-        nw_Font=wxTheFontList->FindOrCreateFont(nw_FontSize, nw_FontFamily,
+        nw_Font=wxTheFontList->FindOrCreateFont(nw_FontSize, (wxFontFamily)nw_FontFamily,
             (attr->style&fsItalic) == 0 ? wxFONTSTYLE_NORMAL : wxFONTSTYLE_ITALIC, 
             (attr->style&fsBold) == 0 ? wxFONTWEIGHT_NORMAL : wxFONTWEIGHT_BOLD,
             (attr->style&fsUnderline) != 0,
@@ -1230,7 +1230,7 @@ void MadSyntax::InitNextWord1(MadLines *madlines, ucs4_t *word, int *widths, con
     nw_FontName=fontname;
     nw_FontSize=fontsize;
     nw_FontFamily=fontfamily;
-    nw_Font=wxTheFontList->FindOrCreateFont(nw_FontSize, nw_FontFamily,
+    nw_Font=wxTheFontList->FindOrCreateFont(nw_FontSize, (wxFontFamily)nw_FontFamily,
         wxFONTSTYLE_NORMAL, wxFONTWEIGHT_NORMAL, false, nw_FontName);
 
     if(m_CaseSensitive)

--- a/src/wxmedit/wxmedit.cpp
+++ b/src/wxmedit/wxmedit.cpp
@@ -1888,7 +1888,7 @@ void MadEdit::PaintTextLines(wxDC *dc, const wxRect &rect, int toprow, int rowco
                 if(c != current_bgcolor)
                 {
                     current_bgcolor = c;
-                    dc->SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxSOLID));
+                    dc->SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxPENSTYLE_SOLID));
                     dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(c));
                     dc->DrawRectangle(minleft, row_top, rectright-minleft, m_RowHeight);
                 }
@@ -1931,12 +1931,12 @@ void MadEdit::PaintTextLines(wxDC *dc, const wxRect &rect, int toprow, int rowco
                             if(m_Syntax->nw_BgColor != current_bgcolor)
                             {
                                 current_bgcolor = m_Syntax->nw_BgColor;
-                                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxSOLID));
+                                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxPENSTYLE_SOLID));
                                 dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(m_Syntax->nw_BgColor));
                                 dc->DrawRectangle(left, row_top, rectright-left, m_RowHeight);
                             }
 
-                            dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_Color, 1, wxSOLID));
+                            dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_Color, 1, wxPENSTYLE_SOLID));
 
                             int idx = 0;
                             int x0 = left;
@@ -1970,7 +1970,7 @@ void MadEdit::PaintTextLines(wxDC *dc, const wxRect &rect, int toprow, int rowco
                             if(m_Syntax->nw_BgColor != current_bgcolor)
                             {
                                 current_bgcolor = m_Syntax->nw_BgColor;
-                                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxSOLID));
+                                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxPENSTYLE_SOLID));
                                 dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(m_Syntax->nw_BgColor));
                                 dc->DrawRectangle(left, row_top, rectright-left, m_RowHeight);
                             }
@@ -2042,12 +2042,12 @@ void MadEdit::PaintTextLines(wxDC *dc, const wxRect &rect, int toprow, int rowco
                 if(m_Syntax->nw_BgColor != current_bgcolor)
                 {
                     current_bgcolor = m_Syntax->nw_BgColor;
-                    dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxSOLID));
+                    dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxPENSTYLE_SOLID));
                     dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(m_Syntax->nw_BgColor));
                     dc->DrawRectangle(left, row_top, rectright-left, m_RowHeight);
                 }
 
-                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_Color, 1, wxSOLID));
+                dc->SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_Color, 1, wxPENSTYLE_SOLID));
                 dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(m_Syntax->nw_Color));
 
                 std::vector<wxPoint>& points = lineiter->m_nl->PatternPoints(this);
@@ -2062,7 +2062,7 @@ void MadEdit::PaintTextLines(wxDC *dc, const wxRect &rect, int toprow, int rowco
                 if(c != current_bgcolor)
                 {
                     dc->SetBrush(*wxTheBrushList->FindOrCreateBrush(c));
-                    dc->SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxSOLID));
+                    dc->SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxPENSTYLE_SOLID));
                     dc->DrawRectangle(left, row_top, rectright-left, m_RowHeight);
                 }
             }
@@ -2215,7 +2215,7 @@ void MadEdit::PaintHexLines(wxDC *dc, wxRect &rect, int toprow, int rowcount, bo
     dc->SetFont(*m_HexFont);
 
     wxColor &markcolor=m_Syntax->GetAttributes(aeActiveLine)->color;
-    dc->SetPen(*wxThePenList->FindOrCreatePen(markcolor, 1, wxSOLID));
+    dc->SetPen(*wxThePenList->FindOrCreatePen(markcolor, 1, wxPENSTYLE_SOLID));
 
 
     if(painthead)
@@ -9129,7 +9129,7 @@ void MadEdit::UpdateClientBitmap()
             wxMemoryDC dc1, dc2;
             dc1.SelectObject(*m_ClientBitmap);
             dc1.SetBrush(*wxTheBrushList->FindOrCreateBrush(*wxWHITE));
-            dc1.SetPen(*wxThePenList->FindOrCreatePen(*wxWHITE, 1, wxSOLID));
+            dc1.SetPen(*wxThePenList->FindOrCreatePen(*wxWHITE, 1, wxPENSTYLE_SOLID));
 
             dc1.DrawRectangle(0, 0, 10, 10);
             dc1.Blit(0,0,10,10,&dc1, 0,0,wxINVERT);
@@ -9393,7 +9393,7 @@ void MadEdit::OnPaint(wxPaintEvent &evt)
                 // clear client area
                 wxColor &bgcolor=m_Syntax->GetAttributes(aeText)->bgcolor;
                 memdc.SetBrush(*wxTheBrushList->FindOrCreateBrush(bgcolor));
-                memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxSOLID));
+                memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxPENSTYLE_SOLID));
                 memdc.DrawRectangle(0, 0, m_ClientWidth, m_ClientHeight);
 
                 // paint rows
@@ -9428,7 +9428,7 @@ void MadEdit::OnPaint(wxPaintEvent &evt)
 
                     wxColor &bgcolor=m_Syntax->GetAttributes(aeText)->bgcolor;
                     memdc.SetBrush(*wxTheBrushList->FindOrCreateBrush(bgcolor));
-                    memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxSOLID));
+                    memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxPENSTYLE_SOLID));
                     memdc.DrawRectangle(rect.x, rect.y, rect.width, rect.height);
 
                     PaintTextLines(&memdc, rect, firstrow, rows, bgcolor);
@@ -9543,7 +9543,7 @@ void MadEdit::OnPaint(wxPaintEvent &evt)
                 }
 
                 wxColor &c=m_Syntax->GetAttributes(aeActiveLine)->color;
-                markdc.SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxSOLID));
+                markdc.SetPen(*wxThePenList->FindOrCreatePen(c, 1, wxPENSTYLE_SOLID));
                 markdc.SetBrush(*wxTRANSPARENT_BRUSH);
 
                 markdc.DrawRectangle(x, y, w, h);
@@ -9599,7 +9599,7 @@ void MadEdit::OnPaint(wxPaintEvent &evt)
                 // clear client area
                 wxColor &bgcolor=m_Syntax->GetAttributes(aeText)->bgcolor;
                 memdc.SetBrush(*wxTheBrushList->FindOrCreateBrush(bgcolor));
-                memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxSOLID));
+                memdc.SetPen(*wxThePenList->FindOrCreatePen(bgcolor, 1, wxPENSTYLE_SOLID));
                 memdc.DrawRectangle(0, 0, m_ClientWidth, m_ClientHeight);
 
                 if(m_HexDigitBitmap==nullptr)
@@ -9619,7 +9619,7 @@ void MadEdit::OnPaint(wxPaintEvent &evt)
 
                     // second line: aeLineNumberArea hexdigit
                     m_Syntax->SetAttributes(aeLineNumber);
-                    memdc.SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxSOLID));
+                    memdc.SetPen(*wxThePenList->FindOrCreatePen(m_Syntax->nw_BgColor, 1, wxPENSTYLE_SOLID));
                     memdc.SetBrush(*wxTheBrushList->FindOrCreateBrush(m_Syntax->nw_BgColor));
                     memdc.DrawRectangle(0, m_RowHeight, m_HexFontMaxDigitWidth*76, m_RowHeight*2);
                     memdc.SetTextForeground(m_Syntax->nw_Color);


### PR DESCRIPTION
When compile on openSUSE Leap 15.0(which have the following version of gcc & wxWidgets)
-  `g++ -v` returns `gcc version 7.3.1`
-  `wx-config --version` returns `3.1.1`

There would be some `deprecated` warnings,such as

-  `src/wxm/edit/inframe.cpp:552:64: warning: ‘wxPen* wxPenList::FindOrCreatePen(const wxColour&, int, int)’ is deprecated: use wxPENSTYLE_XXX constants [-Wdeprecated-declarations]`

-  `src/wxm/status_bar.cpp:26:69: warning: ‘wxFont::wxFont(int, int, int, int, bool, const wxString&, wxFontEncoding)’ is deprecated: use wxFONT{FAMILY,STYLE,WEIGHT}_XXX constants [-Wdeprecated-declarations]`

-  `src/wxmedit/wxm_syntax.cpp:1218:24: warning: ‘wxFont* wxFontList::FindOrCreateFont(int, int, int, int, bool, const wxString&, wxFontEncoding)’ is deprecated: use wxFONT{FAMILY,STYLE,WEIGHT}_XXX constants [-Wdeprecated-declarations]`

Besides, there commit for [fix compatibility with wxWidgets 2.8](https://github.com/wxMEdit/wxMEdit/commit/86d40ce919a0c3945ddca417b6fea3ba67a90611) has a typo which causes compile error (wxMAJOR_VERSION should be 3 instead of 2)

These warnings may become errors with future version of wxWidgets, and I think it is better to fix them. 
Please consider it. 

Thanks for your patient.